### PR TITLE
Fix add items

### DIFF
--- a/src/Pages/ListPage.jsx
+++ b/src/Pages/ListPage.jsx
@@ -227,11 +227,13 @@ export default function ListPage() {
                     <FontAwesomeIcon className="remove-icon"icon={faX} />
                   </div>
                   {/* Call handleCheckToggle with the item's _id when the icon is clicked */}
+                  {checkedItems[item._id] && (
                   <FontAwesomeIcon
                     className="tick"
-                    icon={checkedItems[item._id] ? faCheck : null}
+                    icon={faCheck}
                     onClick={() => handleCheckToggle(item._id)} 
                   />
+                  )}
                   <p
                     className="list-items-label"
                     style={{

--- a/src/Pages/ListPage.jsx
+++ b/src/Pages/ListPage.jsx
@@ -129,18 +129,21 @@ export default function ListPage() {
     }
 
     async function addItemToList(item) {
-        const data = {
-            items: [item]
-        }
-        const response = await editList(_id._id, data, cookie)
-        const checkIfDoubleUp = items.some((item) => item.toString(data))
-        if (checkIfDoubleUp) {
-            return
-        }
-        const newItemArray = response.items
-        console.log(newItemArray)
-        setItems(newItemArray)
-    }
+      const data = {
+          items: [item]
+      };
+      try {
+          const response = await editList(_id._id, data, cookie);
+          
+          // Make sure the response from the API includes the updated list
+          const updatedList = response;
+  
+          // Use the updated list's items for setting state
+          setItems(updatedList.items);
+      } catch (error) {
+          console.error("Error adding item:", error);
+      }
+  }
 
      // State to track if the navigation menu is open or closed
    const [isNavMenuOpen, setIsNavMenuOpen] = useState(false);

--- a/src/Pages/ListPage.jsx
+++ b/src/Pages/ListPage.jsx
@@ -127,23 +127,30 @@ export default function ListPage() {
         handleShowDelete()
         navigate('/')
     }
-
     async function addItemToList(item) {
-      const data = {
-          items: [item]
-      };
-      try {
-          const response = await editList(_id._id, data, cookie);
-          
-          // Make sure the response from the API includes the updated list
-          const updatedList = response;
-  
-          // Use the updated list's items for setting state
-          setItems(updatedList.items);
-      } catch (error) {
-          console.error("Error adding item:", error);
+      const isItemAlreadyAdded = items.some(existingItem => existingItem.name === item.name);
+    
+      if (isItemAlreadyAdded) {
+        console.log("Item already exists in the list");
+        return;
       }
-  }
+    
+      const data = {
+        items: [item]
+      };
+    
+      try {
+        const response = await editList(_id._id, data, cookie);
+    
+        // Make sure the response from the API includes the updated list
+        const updatedList = response;
+    
+        // Use the updated list's items for setting state
+        setItems(updatedList.items);
+      } catch (error) {
+        console.error("Error adding item:", error);
+      }
+    }
 
      // State to track if the navigation menu is open or closed
    const [isNavMenuOpen, setIsNavMenuOpen] = useState(false);
@@ -194,7 +201,7 @@ export default function ListPage() {
         {list && listName ? (
         <div className="list-details-body">
           
-          <FindItem  addItem={addItemToList} />
+          <FindItem addItem={addItemToList} items={items} />
           {showDelete && (
             <DeleteList
               handleCancel={handleShowDelete}


### PR DESCRIPTION
- Fixed error in the console about tick icon being null. There is still another error in the console that needs resolving.

- If an item is added to a list which matches the name of an existing item in the db it just pulls that item from the db and displays it in the list, rather than creating a duplicate new item with a new ID in the db.

- Cannot add a duplicate item to a list now. The item just doesn't add and all that happens is a console.log message is returned. Can return that message to the front end later if required.

- There is currently a minor bug with lists that isn't too much of a concern. 
Typing in an item that already exists brings up the filter/suggestion box. If that is ignored and the user presses enter to an item that already exists, that duplicate is not added to the list, but it's added to the filer. 
To see this issue, open a list, type "1" into the add items field and press enter. Do it 3 more times. Now when typing in "1", the filter/suggestion shows 1 as many times as you entered it. 

However, if you refresh the page and type "1" again, the duplicates will no longer display 